### PR TITLE
feat: Implement sticky columns for data tables

### DIFF
--- a/Ruta1.html
+++ b/Ruta1.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -419,7 +418,7 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 12px;
-            min-width: 1400px;
+            /* min-width: 1400px; */ /* Eliminado para evitar scroll horizontal */
         }
         
         th {
@@ -464,7 +463,7 @@
         .input-cell:focus {
             outline: none;
             border-color: var(--primary-color);
-            box-shadow: 0 0 3px rgba(52, 152, 219, 0.3);
+            box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
         }
         
         .input-cell.error {
@@ -492,6 +491,18 @@
         
         .mejoramiento-header {
             background: linear-gradient(135deg, #e74c3c, #c0392b) !important;
+        }
+
+        .table-title-section {
+            padding: 10px 15px;
+            color: white;
+            border-radius: 8px 8px 0 0;
+            font-size: 18px;
+            font-weight: 600;
+        }
+
+        .table-container-vertical + .table-container-vertical {
+            margin-top: 20px;
         }
         
         .alert {
@@ -541,6 +552,40 @@
 
         .mensaje-confirmacion.mostrar {
             transform: translateX(0);
+        }
+
+        /* --- Sticky Column Styles --- */
+        .editable-table th:nth-child(1), .editable-table td:nth-child(1) { position: sticky; left: 0; }
+        .editable-table th:nth-child(2), .editable-table td:nth-child(2) { position: sticky; left: 80px; }
+        .editable-table th:nth-child(3), .editable-table td:nth-child(3) { position: sticky; left: 160px; }
+
+        /* Z-indexing for sticky header cells */
+        .editable-table thead th:nth-child(1),
+        .editable-table thead th:nth-child(2),
+        .editable-table thead th:nth-child(3) {
+            z-index: 11;
+        }
+
+        /* Z-indexing and background for sticky body cells */
+        .editable-table tbody td:nth-child(1),
+        .editable-table tbody td:nth-child(2),
+        .editable-table tbody td:nth-child(3) {
+            z-index: 1;
+            background-color: white;
+        }
+
+        /* Re-apply even row background for sticky cells */
+        .editable-table tbody tr:nth-child(even) td:nth-child(1),
+        .editable-table tbody tr:nth-child(even) td:nth-child(2),
+        .editable-table tbody tr:nth-child(even) td:nth-child(3) {
+            background-color: #f8f9fa;
+        }
+
+        /* Re-apply hover background for sticky cells */
+        .editable-table tbody tr:hover td:nth-child(1),
+        .editable-table tbody tr:hover td:nth-child(2),
+        .editable-table tbody tr:hover td:nth-child(3) {
+            background-color: #e3f2fd;
         }
         
         @media (max-width: 768px) {
@@ -671,53 +716,64 @@
         <!-- Sección de ingreso de datos -->
         <div class="section data-input-section" id="tabla-container">
             <h2>➕ Ingreso de Datos - <span id="periodo-mostrado"></span></h2>
-            <div class="table-container">
-                <div class="table-wrapper">
-                    <table id="data-table" class="editable-table">
-                        <thead>
-                            <tr>
-                                <th style="width: 80px;">GESTIÓN</th>
-                                <th style="width: 80px;">MES</th>
-                                <th style="width: 180px;">VARIABLES</th>
-                                <th colspan="9" class="ampliacion-header">AMPLIACIÓN</th>
-                                <th style="width: 70px;" class="ampliacion-header">TOTAL(A)</th>
-                                <th colspan="9" class="mejoramiento-header">MEJORAMIENTO</th>
-                                <th style="width: 70px;" class="mejoramiento-header">TOTAL(M)</th>
-                                <th style="width: 70px;">TOTAL GENERAL</th>
-                                <th style="width: 60px;">ACCIONES</th>
-                            </tr>
-                            <tr>
-                                <th></th>
-                                <th></th>
-                                <th></th>
-                                <th style="width: 50px;">COTAHUMA</th>
-                                <th style="width: 50px;">MAX PAREDES</th>
-                                <th style="width: 50px;">PERIFERICA</th>
-                                <th style="width: 50px;">SAN ANTONIO</th>
-                                <th style="width: 50px;">SUR</th>
-                                <th style="width: 50px;">MALLASA</th>
-                                <th style="width: 50px;">CENTRO</th>
-                                <th style="width: 50px;">HAMPATURI</th>
-                                <th style="width: 50px;">ZONGO</th>
-                                <th style="width: 70px;">TOTAL(A)</th>
-                                <th style="width: 50px;">COTAHUMA</th>
-                                <th style="width: 50px;">MAX PAREDES</th>
-                                <th style="width: 50px;">PERIFERICA</th>
-                                <th style="width: 50px;">SAN ANTONIO</th>
-                                <th style="width: 50px;">SUR</th>
-                                <th style="width: 50px;">MALLASA</th>
-                                <th style="width: 50px;">CENTRO</th>
-                                <th style="width: 50px;">HAMPATURI</th>
-                                <th style="width: 50px;">ZONGO</th>
-                                <th style="width: 70px;">TOTAL(M)</th>
-                                <th style="width: 70px;">TOTAL GENERAL</th>
-                                <th style="width: 60px;">ACCIONES</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <!-- Filas dinámicas se cargarán aquí -->
-                        </tbody>
-                    </table>
+
+            <div id="tablas-verticales-container">
+                <div class="table-container-vertical">
+                    <h3 class="table-title-section ampliacion-header">AMPLIACIÓN</h3>
+                    <div class="table-wrapper">
+                        <table id="data-table-ampliacion" class="editable-table">
+                            <thead>
+                                <tr>
+                                    <th style="width: 80px;">GESTIÓN</th>
+                                    <th style="width: 80px;">MES</th>
+                                    <th style="width: 180px;">VARIABLES</th>
+                                    <th style="width: 50px;">COTAHUMA</th>
+                                    <th style="width: 50px;">MAX PAREDES</th>
+                                    <th style="width: 50px;">PERIFERICA</th>
+                                    <th style="width: 50px;">SAN ANTONIO</th>
+                                    <th style="width: 50px;">SUR</th>
+                                    <th style="width: 50px;">MALLASA</th>
+                                    <th style="width: 50px;">CENTRO</th>
+                                    <th style="width: 50px;">HAMPATURI</th>
+                                    <th style="width: 50px;">ZONGO</th>
+                                    <th style="width: 70px;">TOTAL(A)</th>
+                                    <th style="width: 60px;">ACCIONES</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <!-- Filas de Ampliación se cargarán aquí -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <div class="table-container-vertical">
+                    <h3 class="table-title-section mejoramiento-header">MEJORAMIENTO</h3>
+                    <div class="table-wrapper">
+                        <table id="data-table-mejoramiento" class="editable-table">
+                            <thead>
+                                <tr>
+                                    <th style="width: 80px;">GESTIÓN</th>
+                                    <th style="width: 80px;">MES</th>
+                                    <th style="width: 180px;">VARIABLES</th>
+                                    <th style="width: 50px;">COTAHUMA</th>
+                                    <th style="width: 50px;">MAX PAREDES</th>
+                                    <th style="width: 50px;">PERIFERICA</th>
+                                    <th style="width: 50px;">SAN ANTONIO</th>
+                                    <th style="width: 50px;">SUR</th>
+                                    <th style="width: 50px;">MALLASA</th>
+                                    <th style="width: 50px;">CENTRO</th>
+                                    <th style="width: 50px;">HAMPATURI</th>
+                                    <th style="width: 50px;">ZONGO</th>
+                                    <th style="width: 70px;">TOTAL(M)</th>
+                                    <th style="width: 70px;">TOTAL GENERAL</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <!-- Filas de Mejoramiento se cargarán aquí -->
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
@@ -856,24 +912,21 @@
             }, duracion);
         }
 
-        // NUEVA FUNCIÓN: Limpiar datos de las tablas
+        // MODIFIED FUNCTION: Limpiar datos de las tablas
         function limpiarDatos() {
-            // Verificar si hay una tabla cargada
-            const tabla = document.getElementById('data-table');
-            const filas = tabla.querySelectorAll('tbody tr');
+            const filasAmpliacion = document.querySelectorAll('#data-table-ampliacion tbody tr');
+            const filasMejoramiento = document.querySelectorAll('#data-table-mejoramiento tbody tr');
             
-            if (filas.length === 0) {
+            if (filasAmpliacion.length === 0 && filasMejoramiento.length === 0) {
                 mostrarAlerta('No hay datos cargados para limpiar', 'warning');
                 return;
             }
             
-            // Confirmar la acción
-            if (!confirm('¿Está seguro de que desea limpiar todos los datos de la tabla? Esta acción no se puede deshacer.')) {
+            if (!confirm('¿Está seguro de que desea limpiar todos los datos de las tablas? Esta acción no se puede deshacer.')) {
                 return;
             }
             
-            // Limpiar todas las celdas editables
-            const celdasEditables = tabla.querySelectorAll('.input-cell');
+            const celdasEditables = document.querySelectorAll('#data-table-ampliacion .input-cell, #data-table-mejoramiento .input-cell');
             let contador = 0;
             
             celdasEditables.forEach(celda => {
@@ -884,13 +937,9 @@
                 }
             });
             
-            // Recalcular todos los totales (se pondrán en 0)
             calcularTotales();
-            
-            // Actualizar gráficos si están visibles
             actualizarGraficosEnTiempoReal();
             
-            // Mostrar mensaje de confirmación
             mostrarMensajeConfirmacion(`Datos limpiados (${contador} celdas vaciadas)`);
             mostrarAlerta(`✅ Se han limpiado ${contador} celdas de datos correctamente`, 'success');
         }
@@ -936,29 +985,40 @@
             document.getElementById('dashboard-eficiencia').scrollIntoView({ behavior: 'smooth' });
         }
         
-        // NUEVA FUNCIÓN: Calcular métricas de eficiencia
+        // MEJORAR FUNCIÓN: Calcular métricas de eficiencia con validaciones
         function calcularMetricasEficiencia() {
-            const filas = document.querySelectorAll('#data-table tbody tr');
+            const datosSolicitudes = obtenerDatosPorVariable('TOTAL DE SOLICITUDES RECIBIDAS');
+            const datosDisenos = obtenerDatosPorVariable('DISEÑOS TECNICOS APROBADOS');
             
-            if (filas.length < 4) {
+            if (!datosSolicitudes || !datosDisenos) {
                 mostrarAlerta('Debe cargar los datos primero para calcular la eficiencia', 'warning');
-                return;
+                return {
+                    eficienciaAmpliacion: 0,
+                    eficienciaMejoramiento: 0,
+                    promedioEficiencia: 0,
+                    totalSolicitudesAmpliacion: 0,
+                    totalSolicitudesMejoramiento: 0,
+                    totalDisenosAmpliacion: 0,
+                    totalDisenosMejoramiento: 0
+                };
             }
             
-            // Obtener datos de las filas clave
-            const filaTotalSolicitudes = filas[2]; // "N° TOTAL DE SOLICITUDES RECIBIDAS"
-            const filaDisenosAprobados = filas[3]; // "N° DE DISEÑOS TECNICOS APROBADOS"
-            
             // Obtener totales
-            const totalSolicitudesAmpliacion = parseFloat(filaTotalSolicitudes.querySelector('[data-total="ampliacion"]').textContent) || 0;
-            const totalSolicitudesMejoramiento = parseFloat(filaTotalSolicitudes.querySelector('[data-total="mejoramiento"]').textContent) || 0;
-            const totalDisenosAmpliacion = parseFloat(filaDisenosAprobados.querySelector('[data-total="ampliacion"]').textContent) || 0;
-            const totalDisenosMejoramiento = parseFloat(filaDisenosAprobados.querySelector('[data-total="mejoramiento"]').textContent) || 0;
+            const totalSolicitudesAmpliacion = datosSolicitudes.ampliacion.total;
+            const totalSolicitudesMejoramiento = datosSolicitudes.mejoramiento.total;
+            const totalDisenosAmpliacion = datosDisenos.ampliacion.total;
+            const totalDisenosMejoramiento = datosDisenos.mejoramiento.total;
             
-            // Calcular eficiencias
-            const eficienciaAmpliacion = totalSolicitudesAmpliacion > 0 ? (totalDisenosAmpliacion / totalSolicitudesAmpliacion * 100) : 0;
-            const eficienciaMejoramiento = totalSolicitudesMejoramiento > 0 ? (totalDisenosMejoramiento / totalSolicitudesMejoramiento * 100) : 0;
-            const promedioEficiencia = (eficienciaAmpliacion + eficienciaMejoramiento) / 2;
+            // Calcular eficiencias con validación
+            const eficienciaAmpliacion = totalSolicitudesAmpliacion > 0 ?
+                Math.min((totalDisenosAmpliacion / totalSolicitudesAmpliacion * 100), 100) : 0;
+            const eficienciaMejoramiento = totalSolicitudesMejoramiento > 0 ?
+                Math.min((totalDisenosMejoramiento / totalSolicitudesMejoramiento * 100), 100) : 0;
+
+            // Calcular promedio ponderado
+            const totalSolicitudes = totalSolicitudesAmpliacion + totalSolicitudesMejoramiento;
+            const promedioEficiencia = totalSolicitudes > 0 ?
+                ((eficienciaAmpliacion * totalSolicitudesAmpliacion) + (eficienciaMejoramiento * totalSolicitudesMejoramiento)) / totalSolicitudes : 0;
             
             // Actualizar métricas en el DOM
             document.getElementById('total-ampliacion').textContent = totalSolicitudesAmpliacion;
@@ -972,6 +1032,19 @@
             actualizarAnilloProgreso('progress-ampliacion', 'progress-text-ampliacion', eficienciaAmpliacion);
             actualizarAnilloProgreso('progress-mejoramiento', 'progress-text-mejoramiento', eficienciaMejoramiento);
             actualizarAnilloProgreso('progress-promedio', 'progress-text-promedio', promedioEficiencia);
+
+            // Actualizar indicadores de cambio (simulado)
+            actualizarIndicadoresCambio(eficienciaAmpliacion, eficienciaMejoramiento, promedioEficiencia);
+
+            return {
+                eficienciaAmpliacion,
+                eficienciaMejoramiento,
+                promedioEficiencia,
+                totalSolicitudesAmpliacion,
+                totalSolicitudesMejoramiento,
+                totalDisenosAmpliacion,
+                totalDisenosMejoramiento
+            };
         }
         
         // NUEVA FUNCIÓN: Actualizar anillo de progreso
@@ -1342,7 +1415,7 @@
             mostrarAlerta('✅ Datos del dashboard exportados correctamente', 'success');
         }
         
-        // Función para cargar tabla editable
+        // MODIFIED FUNCTION: Cargar tablas editables
         function cargarTabla() {
             const mes = document.getElementById('mes-select').value;
             const gestion = document.getElementById('gestion-select').value || new Date().getFullYear();
@@ -1352,13 +1425,13 @@
                 return;
             }
             
-            // Mostrar tabla (mantener dashboard si ya está activo)
             document.getElementById('tabla-container').classList.add('active');
-            
             document.getElementById('periodo-mostrado').textContent = `${mes} ${gestion}`;
             
-            const tbody = document.querySelector('#data-table tbody');
-            tbody.innerHTML = '';
+            const tbodyAmpliacion = document.querySelector('#data-table-ampliacion tbody');
+            const tbodyMejoramiento = document.querySelector('#data-table-mejoramiento tbody');
+            tbodyAmpliacion.innerHTML = '';
+            tbodyMejoramiento.innerHTML = '';
             
             const variables = [
                 'N° DE SOLICITUDES RECIBIDAS',
@@ -1368,18 +1441,20 @@
             ];
             
             variables.forEach((variable, index) => {
-                const fila = crearFilaEditable(gestion, mes, variable, index);
-                tbody.appendChild(fila);
+                const id = generarId();
+                const filaAmpliacion = crearFilaAmpliacion(gestion, mes, variable, index, id);
+                const filaMejoramiento = crearFilaMejoramiento(gestion, mes, variable, index, id);
+                tbodyAmpliacion.appendChild(filaAmpliacion);
+                tbodyMejoramiento.appendChild(filaMejoramiento);
             });
             
-            // Scroll a la tabla
             document.getElementById('tabla-container').scrollIntoView({ behavior: 'smooth' });
         }
         
-        // Función para crear fila editable
-        function crearFilaEditable(gestion, mes, variable, index) {
+        // NEW FUNCTION: Crear fila para tabla de Ampliación
+        function crearFilaAmpliacion(gestion, mes, variable, index, id) {
             const fila = document.createElement('tr');
-            fila.dataset.id = generarId();
+            fila.dataset.id = id;
             fila.dataset.filaIndex = index;
             
             const macrodistritos = ['cotahuma', 'max_paredes', 'periferica', 'san_antonio', 'zona_sur', 'mallasa', 'centro', 'hampaturi', 'zongo'];
@@ -1390,65 +1465,89 @@
                 <td class="variable-cell">${variable}</td>
             `;
             
-            // Columnas de ampliación
             macrodistritos.forEach(macro => {
                 const readonly = index === 2 ? 'readonly style="background-color: #f0f0f0;"' : '';
                 html += `<td><input type="number" class="input-cell" data-tipo="ampliacion" data-macro="${macro}" min="0" step="1" onchange="calcularTotalesFila(this)" ${readonly}></td>`;
             });
             html += `<td class="total-cell" data-total="ampliacion">0</td>`;
+            html += `<td><button class="btn btn-danger" onclick="eliminarFila(this)" style="padding: 5px 10px; font-size: 12px;">🗑️</button></td>`;
+
+            fila.innerHTML = html;
+            return fila;
+        }
+
+        // NEW FUNCTION: Crear fila para tabla de Mejoramiento
+        function crearFilaMejoramiento(gestion, mes, variable, index, id) {
+            const fila = document.createElement('tr');
+            fila.dataset.id = id;
+            fila.dataset.filaIndex = index;
+
+            const macrodistritos = ['cotahuma', 'max_paredes', 'periferica', 'san_antonio', 'zona_sur', 'mallasa', 'centro', 'hampaturi', 'zongo'];
+
+            let html = `
+                <td class="variable-cell">${gestion}</td>
+                <td class="variable-cell">${mes}</td>
+                <td class="variable-cell">${variable}</td>
+            `;
             
-            // Columnas de mejoramiento
             macrodistritos.forEach(macro => {
                 const readonly = index === 2 ? 'readonly style="background-color: #f0f0f0;"' : '';
                 html += `<td><input type="number" class="input-cell" data-tipo="mejoramiento" data-macro="${macro}" min="0" step="1" onchange="calcularTotalesFila(this)" ${readonly}></td>`;
             });
             html += `<td class="total-cell" data-total="mejoramiento">0</td>`;
             html += `<td class="total-cell" data-total="general">0</td>`;
-            html += `<td><button class="btn btn-danger" onclick="eliminarFila(this)" style="padding: 5px 10px; font-size: 12px;">🗑️</button></td>`;
             
             fila.innerHTML = html;
             return fila;
         }
         
-        // Función para calcular totales de fila con actualización automática
+        // MODIFIED FUNCTION: Calcular totales de fila con actualización automática
         function calcularTotalesFila(input) {
             const fila = input.closest('tr');
-            const filaIndex = parseInt(fila.dataset.filaIndex);
+            const tipo = input.dataset.tipo;
+            const inputs = fila.querySelectorAll(`.input-cell[data-tipo="${tipo}"]`);
             
-            if (filaIndex === 2) {
-                return;
-            }
-            
-            const inputs = fila.querySelectorAll('.input-cell');
-            
-            let totalAmpliacion = 0;
-            let totalMejoramiento = 0;
-            
+            let total = 0;
             inputs.forEach(inp => {
-                const valor = validarNumero(inp.value);
-                if (inp.dataset.tipo === 'ampliacion') {
-                    totalAmpliacion += valor;
-                } else if (inp.dataset.tipo === 'mejoramiento') {
-                    totalMejoramiento += valor;
-                }
+                total += validarNumero(inp.value);
             });
             
-            const totalGeneral = totalAmpliacion + totalMejoramiento;
-            
-            fila.querySelector('[data-total="ampliacion"]').textContent = totalAmpliacion;
-            fila.querySelector('[data-total="mejoramiento"]').textContent = totalMejoramiento;
-            fila.querySelector('[data-total="general"]').textContent = totalGeneral;
+            fila.querySelector(`[data-total="${tipo}"]`).textContent = total;
             
             validarCelda(input);
             actualizarTerceraFila();
+            calcularTotalGeneralFila(fila.dataset.id);
             
-            // Actualizar gráficos en tiempo real si el dashboard está activo
             actualizarGraficosEnTiempoReal();
         }
-        
-        // Función para actualizar la tercera fila
+
+        // NEW FUNCTION: Calcular el total general para un par de filas
+        function calcularTotalGeneralFila(id) {
+            const filaAmpliacion = document.querySelector(`#data-table-ampliacion tr[data-id="${id}"]`);
+            const filaMejoramiento = document.querySelector(`#data-table-mejoramiento tr[data-id="${id}"]`);
+
+            if (filaAmpliacion && filaMejoramiento) {
+                const totalAmpliacion = parseFloat(filaAmpliacion.querySelector('[data-total="ampliacion"]').textContent) || 0;
+                const totalMejoramiento = parseFloat(filaMejoramiento.querySelector('[data-total="mejoramiento"]').textContent) || 0;
+                const totalGeneral = totalAmpliacion + totalMejoramiento;
+
+                filaMejoramiento.querySelector('[data-total="general"]').textContent = totalGeneral;
+            }
+        }
+
+        // MODIFIED FUNCTION: Actualizar la tercera fila
         function actualizarTerceraFila() {
-            const filas = document.querySelectorAll('#data-table tbody tr');
+            actualizarTerceraFilaParaTabla('data-table-ampliacion');
+            actualizarTerceraFilaParaTabla('data-table-mejoramiento');
+            const filaAmp = document.querySelector('#data-table-ampliacion tbody tr:nth-child(3)');
+            if(filaAmp) {
+                calcularTotalGeneralFila(filaAmp.dataset.id);
+            }
+        }
+
+        // NEW HELPER FUNCTION: Actualizar la tercera fila para una tabla específica
+        function actualizarTerceraFilaParaTabla(tableId) {
+            const filas = document.querySelectorAll(`#${tableId} tbody tr`);
             
             if (filas.length >= 3) {
                 const fila1 = filas[0];
@@ -1456,42 +1555,27 @@
                 const fila3 = filas[2];
                 
                 const macrodistritos = ['cotahuma', 'max_paredes', 'periferica', 'san_antonio', 'zona_sur', 'mallasa', 'centro', 'hampaturi', 'zongo'];
-                const tipos = ['ampliacion', 'mejoramiento'];
+                const tipo = tableId.includes('ampliacion') ? 'ampliacion' : 'mejoramiento';
                 
-                let totalAmpliacion = 0;
-                let totalMejoramiento = 0;
+                let total = 0;
                 
                 macrodistritos.forEach(macro => {
-                    tipos.forEach(tipo => {
-                        const input1 = fila1.querySelector(`[data-tipo="${tipo}"][data-macro="${macro}"]`);
-                        const input2 = fila2.querySelector(`[data-tipo="${tipo}"][data-macro="${macro}"]`);
-                        const input3 = fila3.querySelector(`[data-tipo="${tipo}"][data-macro="${macro}"]`);
-                        
-                        const valor1 = validarNumero(input1 ? input1.value : 0);
-                        const valor2 = validarNumero(input2 ? input2.value : 0);
-                        const suma = valor1 + valor2;
-                        
-                        if (input3) {
-                            input3.value = suma;
-                        }
-                        
-                        if (tipo === 'ampliacion') {
-                            totalAmpliacion += suma;
-                        } else {
-                            totalMejoramiento += suma;
-                        }
-                    });
+                    const input1 = fila1.querySelector(`[data-macro="${macro}"]`);
+                    const input2 = fila2.querySelector(`[data-macro="${macro}"]`);
+                    const input3 = fila3.querySelector(`[data-macro="${macro}"]`);
+
+                    const valor1 = validarNumero(input1 ? input1.value : 0);
+                    const valor2 = validarNumero(input2 ? input2.value : 0);
+                    const suma = valor1 + valor2;
+
+                    if (input3) {
+                        input3.value = suma;
+                    }
+                    total += suma;
                 });
                 
-                const totalGeneral = totalAmpliacion + totalMejoramiento;
-                
-                const totalAmpliacionCell = fila3.querySelector('[data-total="ampliacion"]');
-                const totalMejoramientoCell = fila3.querySelector('[data-total="mejoramiento"]');
-                const totalGeneralCell = fila3.querySelector('[data-total="general"]');
-                
-                if (totalAmpliacionCell) totalAmpliacionCell.textContent = totalAmpliacion;
-                if (totalMejoramientoCell) totalMejoramientoCell.textContent = totalMejoramiento;
-                if (totalGeneralCell) totalGeneralCell.textContent = totalGeneral;
+                const totalCell = fila3.querySelector(`[data-total="${tipo}"]`);
+                if (totalCell) totalCell.textContent = total;
             }
         }
         
@@ -1516,18 +1600,38 @@
             return true;
         }
         
-        // Función para eliminar fila
+        // MODIFIED FUNCTION: Eliminar fila de ambas tablas
         function eliminarFila(boton) {
-            if (confirm('¿Está seguro de eliminar esta fila?')) {
-                boton.closest('tr').remove();
-                mostrarAlerta('Fila eliminada correctamente', 'success');
+            if (confirm('¿Está seguro de eliminar esta fila? (Se eliminará de ambas tablas)')) {
+                const filaAEliminar = boton.closest('tr');
+                const id = filaAEliminar.dataset.id;
+
+                const otraFila = document.querySelector(`#data-table-mejoramiento tr[data-id="${id}"]`);
+
+                filaAEliminar.remove();
+                if (otraFila) {
+                    otraFila.remove();
+                }
+
+                mostrarAlerta('Fila eliminada correctamente de ambas tablas', 'success');
             }
         }
         
-        // Función para calcular todos los totales
+        // MODIFIED FUNCTION: Calcular todos los totales
         function calcularTotales() {
-            const filas = document.querySelectorAll('#data-table tbody tr');
-            filas.forEach(fila => {
+            const filasAmpliacion = document.querySelectorAll('#data-table-ampliacion tbody tr');
+            filasAmpliacion.forEach(fila => {
+                const filaIndex = parseInt(fila.dataset.filaIndex);
+                if (filaIndex !== 2) {
+                    const primerInput = fila.querySelector('.input-cell');
+                    if (primerInput) {
+                        calcularTotalesFila(primerInput);
+                    }
+                }
+            });
+
+            const filasMejoramiento = document.querySelectorAll('#data-table-mejoramiento tbody tr');
+            filasMejoramiento.forEach(fila => {
                 const filaIndex = parseInt(fila.dataset.filaIndex);
                 if (filaIndex !== 2) {
                     const primerInput = fila.querySelector('.input-cell');
@@ -1539,25 +1643,32 @@
             mostrarAlerta('Totales recalculados correctamente', 'success');
         }
         
-        // FUNCIÓN MODIFICADA: Guardar datos con mensaje personalizado
+        // MODIFIED FUNCTION: Guardar datos
         function guardarDatos() {
-            const filas = document.querySelectorAll('#data-table tbody tr');
+            const filasAmpliacion = document.querySelectorAll('#data-table-ampliacion tbody tr');
             
-            if (filas.length === 0) {
+            if (filasAmpliacion.length === 0) {
                 mostrarAlerta('No hay datos para guardar. Primero cargue una tabla.', 'warning');
                 return;
             }
             
             const nuevosRegistros = [];
             
-            filas.forEach(fila => {
-                const gestion = fila.children[0].textContent;
-                const mes = fila.children[1].textContent;
-                const variable = fila.children[2].textContent;
-                const inputs = fila.querySelectorAll('.input-cell');
+            filasAmpliacion.forEach(filaAmp => {
+                const id = filaAmp.dataset.id;
+                const filaMej = document.querySelector(`#data-table-mejoramiento tr[data-id="${id}"]`);
+
+                if (!filaMej) {
+                    console.error(`No se encontró fila de mejoramiento para id ${id}`);
+                    return;
+                }
+
+                const gestion = filaAmp.children[0].textContent;
+                const mes = filaAmp.children[1].textContent;
+                const variable = filaAmp.children[2].textContent;
                 
                 const registro = {
-                    id: fila.dataset.id || generarId(),
+                    id: id,
                     gestion: parseInt(gestion),
                     mes: mes,
                     variable: variable,
@@ -1566,18 +1677,20 @@
                 };
                 
                 const macrodistritos = ['cotahuma', 'max_paredes', 'periferica', 'san_antonio', 'zona_sur', 'mallasa', 'centro', 'hampaturi', 'zongo'];
+                const inputsAmp = filaAmp.querySelectorAll('.input-cell');
+                const inputsMej = filaMej.querySelectorAll('.input-cell');
                 
                 macrodistritos.forEach((macro, index) => {
                     registro.macrodistritos[macro] = {
-                        ampliacion: validarNumero(inputs[index] ? inputs[index].value : 0),
-                        mejoramiento: validarNumero(inputs[index + 9] ? inputs[index + 9].value : 0)
+                        ampliacion: validarNumero(inputsAmp[index] ? inputsAmp[index].value : 0),
+                        mejoramiento: validarNumero(inputsMej[index] ? inputsMej[index].value : 0)
                     };
                 });
                 
                 registro.totales = {
-                    ampliacion: parseFloat(fila.querySelector('[data-total="ampliacion"]').textContent),
-                    mejoramiento: parseFloat(fila.querySelector('[data-total="mejoramiento"]').textContent),
-                    general: parseFloat(fila.querySelector('[data-total="general"]').textContent)
+                    ampliacion: parseFloat(filaAmp.querySelector('[data-total="ampliacion"]').textContent),
+                    mejoramiento: parseFloat(filaMej.querySelector('[data-total="mejoramiento"]').textContent),
+                    general: parseFloat(filaMej.querySelector('[data-total="general"]').textContent)
                 };
                 
                 nuevosRegistros.push(registro);
@@ -1594,159 +1707,87 @@
             
             localStorage.setItem('datosAlumbrado', JSON.stringify(datosGuardados));
             
-            // Mostrar mensaje de confirmación personalizado
             mostrarMensajeConfirmacion('datos guardados');
             mostrarAlerta('✅ Datos guardados correctamente en el almacenamiento local', 'success');
         }
         
-        // NUEVA FUNCIÓN: Cargar datos de ejemplo
+        // MODIFIED FUNCTION: Cargar datos de ejemplo
         function cargarDatosEjemplo() {
-            // Primero cargar la tabla
             document.getElementById('mes-select').value = 'JULIO';
             document.getElementById('gestion-select').value = '2025';
             cargarTabla();
             
-            // Esperar un momento para que se cargue la tabla
             setTimeout(() => {
-                const filas = document.querySelectorAll('#data-table tbody tr');
+                const filasAmp = document.querySelectorAll('#data-table-ampliacion tbody tr');
+                const filasMej = document.querySelectorAll('#data-table-mejoramiento tbody tr');
                 
-                if (filas.length >= 4) {
-                    // Datos de ejemplo para "N° DE SOLICITUDES RECIBIDAS"
-                    const fila1Inputs = filas[0].querySelectorAll('.input-cell');
-                    const datosRecibidas = [8, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // Ampliación y Mejoramiento
-                    fila1Inputs.forEach((input, index) => {
-                        if (index < datosRecibidas.length) {
-                            input.value = datosRecibidas[index];
-                        }
-                    });
+                if (filasAmp.length >= 4) {
+                    // Fila 1 - Solicitudes Recibidas
+                    const fila1InputsAmp = filasAmp[0].querySelectorAll('.input-cell');
+                    [8, 0, 0, 0, 8, 0, 0, 0, 0].forEach((v, i) => { if(fila1InputsAmp[i]) fila1InputsAmp[i].value = v });
+                    const fila1InputsMej = filasMej[0].querySelectorAll('.input-cell');
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0].forEach((v, i) => { if(fila1InputsMej[i]) fila1InputsMej[i].value = v });
                     
-                    // Datos de ejemplo para "N° DE SOLICITUDES PENDIENTES DEL MES ANTERIOR"
-                    const fila2Inputs = filas[1].querySelectorAll('.input-cell');
-                    const datosPendientes = [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // Ampliación y Mejoramiento
-                    fila2Inputs.forEach((input, index) => {
-                        if (index < datosPendientes.length) {
-                            input.value = datosPendientes[index];
-                        }
-                    });
+                    // Fila 2 - Pendientes
+                    const fila2InputsAmp = filasAmp[1].querySelectorAll('.input-cell');
+                    [8, 0, 0, 0, 0, 0, 0, 0, 0].forEach((v, i) => { if(fila2InputsAmp[i]) fila2InputsAmp[i].value = v });
+                    const fila2InputsMej = filasMej[1].querySelectorAll('.input-cell');
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0].forEach((v, i) => { if(fila2InputsMej[i]) fila2InputsMej[i].value = v });
+
+                    // Fila 4 - Aprobados
+                    const fila4InputsAmp = filasAmp[3].querySelectorAll('.input-cell');
+                    [2, 0, 0, 0, 0, 0, 0, 0, 0].forEach((v, i) => { if(fila4InputsAmp[i]) fila4InputsAmp[i].value = v });
+                    const fila4InputsMej = filasMej[3].querySelectorAll('.input-cell');
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0].forEach((v, i) => { if(fila4InputsMej[i]) fila4InputsMej[i].value = v });
                     
-                    // Datos de ejemplo para "N° DE DISEÑOS TECNICOS APROBADOS"
-                    const fila4Inputs = filas[3].querySelectorAll('.input-cell');
-                    const datosAprobados = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // Ampliación y Mejoramiento
-                    fila4Inputs.forEach((input, index) => {
-                        if (index < datosAprobados.length) {
-                            input.value = datosAprobados[index];
-                        }
-                    });
-                    
-                    // Calcular totales
                     calcularTotales();
-                    
                     mostrarAlerta('✅ Datos de ejemplo cargados correctamente', 'success');
                 }
             }, 500);
         }
         
-        // NUEVA FUNCIÓN: Obtener datos por variable y tipo
+        // MODIFIED FUNCTION: Obtener datos por variable y tipo
         function obtenerDatosPorVariable(nombreVariable, tipo = null) {
-            const filas = document.querySelectorAll('#data-table tbody tr');
-            let filaEncontrada = null;
+            const filasAmpliacion = document.querySelectorAll('#data-table-ampliacion tbody tr');
+            let filaAmpliacionEncontrada = null;
             
-            // Buscar la fila que contiene la variable
-            filas.forEach(fila => {
+            filasAmpliacion.forEach(fila => {
                 const variableCell = fila.querySelector('.variable-cell:nth-child(3)');
                 if (variableCell && variableCell.textContent.includes(nombreVariable)) {
-                    filaEncontrada = fila;
+                    filaAmpliacionEncontrada = fila;
                 }
             });
             
-            if (!filaEncontrada) return null;
+            if (!filaAmpliacionEncontrada) return null;
+
+            const id = filaAmpliacionEncontrada.dataset.id;
+            const filaMejoramientoEncontrada = document.querySelector(`#data-table-mejoramiento tr[data-id="${id}"]`);
+
+            if (!filaMejoramientoEncontrada) return null;
             
             const datos = {
                 ampliacion: {
-                    total: parseFloat(filaEncontrada.querySelector('[data-total="ampliacion"]').textContent) || 0,
+                    total: parseFloat(filaAmpliacionEncontrada.querySelector('[data-total="ampliacion"]').textContent) || 0,
                     macrodistritos: {}
                 },
                 mejoramiento: {
-                    total: parseFloat(filaEncontrada.querySelector('[data-total="mejoramiento"]').textContent) || 0,
+                    total: parseFloat(filaMejoramientoEncontrada.querySelector('[data-total="mejoramiento"]').textContent) || 0,
                     macrodistritos: {}
                 },
-                totalGeneral: parseFloat(filaEncontrada.querySelector('[data-total="general"]').textContent) || 0
+                totalGeneral: parseFloat(filaMejoramientoEncontrada.querySelector('[data-total="general"]').textContent) || 0
             };
             
-            // Obtener datos por macrodistrito
             const macrodistritos = ['cotahuma', 'max_paredes', 'periferica', 'san_antonio', 'zona_sur', 'mallasa', 'centro', 'hampaturi', 'zongo'];
             
-            macrodistritos.forEach(macro => {
-                const inputAmpliacion = filaEncontrada.querySelector(`[data-tipo="ampliacion"][data-macro="${macro}"]`);
-                const inputMejoramiento = filaEncontrada.querySelector(`[data-tipo="mejoramiento"][data-macro="${macro}"]`);
-                
+            macrodistritos.forEach((macro, i) => {
+                const inputAmpliacion = filaAmpliacionEncontrada.querySelectorAll('.input-cell')[i];
                 datos.ampliacion.macrodistritos[macro] = inputAmpliacion ? (parseFloat(inputAmpliacion.value) || 0) : 0;
+
+                const inputMejoramiento = filaMejoramientoEncontrada.querySelectorAll('.input-cell')[i];
                 datos.mejoramiento.macrodistritos[macro] = inputMejoramiento ? (parseFloat(inputMejoramiento.value) || 0) : 0;
             });
             
             return tipo ? datos[tipo] : datos;
-        }
-        
-        // MEJORAR FUNCIÓN: Calcular métricas de eficiencia con validaciones
-        function calcularMetricasEficiencia() {
-            const datosSolicitudes = obtenerDatosPorVariable('TOTAL DE SOLICITUDES RECIBIDAS');
-            const datosDisenos = obtenerDatosPorVariable('DISEÑOS TECNICOS APROBADOS');
-            
-            if (!datosSolicitudes || !datosDisenos) {
-                mostrarAlerta('Debe cargar los datos primero para calcular la eficiencia', 'warning');
-                return {
-                    eficienciaAmpliacion: 0,
-                    eficienciaMejoramiento: 0,
-                    promedioEficiencia: 0,
-                    totalSolicitudesAmpliacion: 0,
-                    totalSolicitudesMejoramiento: 0,
-                    totalDisenosAmpliacion: 0,
-                    totalDisenosMejoramiento: 0
-                };
-            }
-            
-            // Obtener totales
-            const totalSolicitudesAmpliacion = datosSolicitudes.ampliacion.total;
-            const totalSolicitudesMejoramiento = datosSolicitudes.mejoramiento.total;
-            const totalDisenosAmpliacion = datosDisenos.ampliacion.total;
-            const totalDisenosMejoramiento = datosDisenos.mejoramiento.total;
-            
-            // Calcular eficiencias con validación
-            const eficienciaAmpliacion = totalSolicitudesAmpliacion > 0 ? 
-                Math.min((totalDisenosAmpliacion / totalSolicitudesAmpliacion * 100), 100) : 0;
-            const eficienciaMejoramiento = totalSolicitudesMejoramiento > 0 ? 
-                Math.min((totalDisenosMejoramiento / totalSolicitudesMejoramiento * 100), 100) : 0;
-            
-            // Calcular promedio ponderado
-            const totalSolicitudes = totalSolicitudesAmpliacion + totalSolicitudesMejoramiento;
-            const promedioEficiencia = totalSolicitudes > 0 ? 
-                ((eficienciaAmpliacion * totalSolicitudesAmpliacion) + (eficienciaMejoramiento * totalSolicitudesMejoramiento)) / totalSolicitudes : 0;
-            
-            // Actualizar métricas en el DOM
-            document.getElementById('total-ampliacion').textContent = totalSolicitudesAmpliacion;
-            document.getElementById('total-mejoramiento').textContent = totalSolicitudesMejoramiento;
-            document.getElementById('eficiencia-ampliacion').textContent = eficienciaAmpliacion.toFixed(1) + '%';
-            document.getElementById('eficiencia-mejoramiento').textContent = eficienciaMejoramiento.toFixed(1) + '%';
-            document.getElementById('total-general').textContent = totalSolicitudesAmpliacion + totalSolicitudesMejoramiento;
-            document.getElementById('promedio-eficiencia').textContent = promedioEficiencia.toFixed(1) + '%';
-            
-            // Actualizar anillos de progreso
-            actualizarAnilloProgreso('progress-ampliacion', 'progress-text-ampliacion', eficienciaAmpliacion);
-            actualizarAnilloProgreso('progress-mejoramiento', 'progress-text-mejoramiento', eficienciaMejoramiento);
-            actualizarAnilloProgreso('progress-promedio', 'progress-text-promedio', promedioEficiencia);
-            
-            // Actualizar indicadores de cambio (simulado)
-            actualizarIndicadoresCambio(eficienciaAmpliacion, eficienciaMejoramiento, promedioEficiencia);
-            
-            return {
-                eficienciaAmpliacion,
-                eficienciaMejoramiento,
-                promedioEficiencia,
-                totalSolicitudesAmpliacion,
-                totalSolicitudesMejoramiento,
-                totalDisenosAmpliacion,
-                totalDisenosMejoramiento
-            };
         }
         
         // NUEVA FUNCIÓN: Actualizar indicadores de cambio


### PR DESCRIPTION
This change adds CSS rules to make the first three columns ("GESTIÓN", "MES", "VARIABLES") of the data input tables sticky.

This improves usability by keeping the row context visible while scrolling horizontally to enter data in the rightmost columns. The implementation uses `position: sticky` and ensures correct z-indexing and background colors to prevent visual glitches.